### PR TITLE
Fix image limit issue by saving image paths instead of BLOBs

### DIFF
--- a/app/schemas/com.example.rezeptliste2.database.Database/4.json
+++ b/app/schemas/com.example.rezeptliste2.database.Database/4.json
@@ -6,7 +6,7 @@
     "entities": [
       {
         "tableName": "Rezept",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`r_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `dauer` INTEGER, `zubereitung` TEXT, `bild` BLOB)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`r_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `dauer` INTEGER, `zubereitung` TEXT, `bild` TEXT)",
         "fields": [
           {
             "fieldPath": "r_id",
@@ -35,7 +35,7 @@
           {
             "fieldPath": "bild",
             "columnName": "bild",
-            "affinity": "BLOB",
+            "affinity": "TEXT",
             "notNull": false
           }
         ],

--- a/app/src/main/java/com/example/rezeptliste2/database/Database.kt
+++ b/app/src/main/java/com/example/rezeptliste2/database/Database.kt
@@ -16,5 +16,3 @@ abstract class Database : RoomDatabase() {
     abstract fun zutatDao(): ZutatDao
     abstract fun rezeptZutatDao(): RezeptZutatDao
 }
-
-

--- a/app/src/main/java/com/example/rezeptliste2/database/dao/RecipeDao.kt
+++ b/app/src/main/java/com/example/rezeptliste2/database/dao/RecipeDao.kt
@@ -25,11 +25,8 @@ interface RecipeDao {
     fun update(rezept: Recipe)
 
     @Query("INSERT INTO rezept (name, dauer, zubereitung, bild) VALUES (:name, :dauer, :zubereitung, :bild)")
-    fun insert(name: String, dauer: Int?, zubereitung: String?, bild: ByteArray?)
+    fun insert(name: String, dauer: Int?, zubereitung: String?, bild: String?)
 
     @Delete
     fun delete(rezept: Recipe)
-
-
-
 }

--- a/app/src/main/java/com/example/rezeptliste2/database/dto/Recipe.kt
+++ b/app/src/main/java/com/example/rezeptliste2/database/dto/Recipe.kt
@@ -9,7 +9,7 @@ data class Recipe(
     var name: String,
     var dauer: Int?,
     var zubereitung: String?,
-    val bild: ByteArray?,
+    val bild: String?,
 ) {
     constructor() : this(0, "", 0, "", null)
 }


### PR DESCRIPTION
Fixes #1

Update the application to save image paths instead of BLOBs in the database.

* **ComposeCookingRecipeTab.kt**
  - Import necessary classes for file handling.
  - Update `ComposeAddButton` to initialize `bild` as null.
  - Change `onImageClick` parameter type from `ByteArray` to `String`.
  - Modify `ComposeRecipeCardDetailViewHeader` to save image paths to the database.
  - Update `ComposeRecipeImage` to load images from file paths instead of BLOBs.
  - Remove unused functions `bitmapImageToByteArray` and `byteArrayToBitmapImage`.

* **Recipe.kt**
  - Change `bild` field type from `ByteArray?` to `String?`.

* **RecipeDao.kt**
  - Update `insert` method to handle `bild` as `String?` instead of `ByteArray?`.

* **Database.kt**
  - No significant changes, just formatting.

* **4.json**
  - Update schema to reflect changes in `Recipe` entity, changing `bild` field type from `BLOB` to `TEXT`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Resch-Said/Rezeptliste2/pull/4?shareId=befee867-f639-4527-bb29-48317f1d1245).